### PR TITLE
feat: Transactional Outbox Pattern 적용 — 이벤트 유실 방지

### DIFF
--- a/src/main/java/com/flab/woowahaneats/WoowahanEatsApplication.java
+++ b/src/main/java/com/flab/woowahaneats/WoowahanEatsApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
 @EnableRetry
+@EnableScheduling
 public class WoowahanEatsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/flab/woowahaneats/domain/delivery/application/DeliveryEventHandler.java
+++ b/src/main/java/com/flab/woowahaneats/domain/delivery/application/DeliveryEventHandler.java
@@ -1,32 +1,12 @@
 package com.flab.woowahaneats.domain.delivery.application;
 
-import com.flab.woowahaneats.domain.delivery.event.DeliveryCancelledEvent;
-import com.flab.woowahaneats.domain.delivery.event.DeliveryCompletedEvent;
-import com.flab.woowahaneats.domain.delivery.event.DeliveryCreatedEvent;
 import com.flab.woowahaneats.domain.order.user.application.UserOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class DeliveryEventHandler {
 
     private final UserOrderService userOrderService;
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryCreated(DeliveryCreatedEvent event) {
-        userOrderService.startDelivering(event.orderId());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryCancelled(DeliveryCancelledEvent event) {
-        userOrderService.resetOrderToReady(event.orderId());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryCompleted(DeliveryCompletedEvent event) {
-        userOrderService.completeOrder(event.orderId());
-    }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/delivery/application/DeliveryServiceImpl.java
+++ b/src/main/java/com/flab/woowahaneats/domain/delivery/application/DeliveryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.flab.woowahaneats.domain.delivery.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.woowahaneats.domain.delivery.controller.dto.DeliveryResponse;
 import com.flab.woowahaneats.domain.delivery.domain.Delivery;
 import com.flab.woowahaneats.domain.delivery.domain.DeliveryStatus;
@@ -16,11 +17,12 @@ import com.flab.woowahaneats.domain.order.owner.domain.OwnerOrderStatus;
 import com.flab.woowahaneats.domain.order.owner.repository.OwnerOrderRepository;
 import com.flab.woowahaneats.domain.order.user.domain.UserOrder;
 import com.flab.woowahaneats.domain.order.user.repository.UserOrderRepository;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEvent;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEventRepository;
 import com.flab.woowahaneats.domain.rider.domain.Rider;
 import com.flab.woowahaneats.domain.rider.exception.RiderNotFoundException;
 import com.flab.woowahaneats.domain.rider.repository.RiderRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +36,8 @@ public class DeliveryServiceImpl implements DeliveryService {
     private final OwnerOrderRepository ownerOrderRepository;
     private final UserOrderRepository userOrderRepository;
     private final RiderRepository riderRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -52,7 +55,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         Delivery delivery = Delivery.create(userOrder);
         deliveryRepository.save(delivery);
 
-        eventPublisher.publishEvent(new DeliveryCreatedEvent(delivery.getId(), userOrderId));
+        outboxEventRepository.save(OutboxEvent.create("DeliveryCreatedEvent", serialize(new DeliveryCreatedEvent(delivery.getId(), userOrderId))));
     }
 
     @Override
@@ -65,7 +68,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         delivery.cancel();
         deliveryRepository.save(delivery);
 
-        eventPublisher.publishEvent(new DeliveryCancelledEvent(delivery.getId(), delivery.getOrder().getId(), riderId));
+        outboxEventRepository.save(OutboxEvent.create("DeliveryCancelledEvent", serialize(new DeliveryCancelledEvent(delivery.getId(), delivery.getOrder().getId(), riderId))));
     }
 
     @Override
@@ -90,7 +93,7 @@ public class DeliveryServiceImpl implements DeliveryService {
         delivery.accept(rider);
         deliveryRepository.save(delivery);
 
-        eventPublisher.publishEvent(new DeliveryAcceptedEvent(delivery.getId(), delivery.getOrder().getId(), riderId));
+        outboxEventRepository.save(OutboxEvent.create("DeliveryAcceptedEvent", serialize(new DeliveryAcceptedEvent(delivery.getId(), delivery.getOrder().getId(), riderId))));
     }
 
     @Override
@@ -133,6 +136,14 @@ public class DeliveryServiceImpl implements DeliveryService {
         delivery.complete();
         deliveryRepository.save(delivery);
 
-        eventPublisher.publishEvent(new DeliveryCompletedEvent(delivery.getId(), delivery.getOrder().getId(), riderId));
+        outboxEventRepository.save(OutboxEvent.create("DeliveryCompletedEvent", serialize(new DeliveryCompletedEvent(delivery.getId(), delivery.getOrder().getId(), riderId))));
+    }
+
+    private String serialize(Object event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 직렬화 실패: " + event.getClass().getSimpleName(), e);
+        }
     }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/order/owner/application/OwnerOrderEventHandler.java
+++ b/src/main/java/com/flab/woowahaneats/domain/order/owner/application/OwnerOrderEventHandler.java
@@ -1,32 +1,11 @@
 package com.flab.woowahaneats.domain.order.owner.application;
 
-import com.flab.woowahaneats.domain.order.user.event.UserOrderCancelledEvent;
-import com.flab.woowahaneats.domain.payment.event.PaymentCompletedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class OwnerOrderEventHandler {
 
     private final OwnerOrderService ownerOrderService;
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handlePaymentCompleted(PaymentCompletedEvent event) {
-        ownerOrderService.createOrder(
-                event.userOrderId(),
-                event.orderMenus(),
-                event.orderRequest(),
-                event.orderPrice(),
-                event.deliveryAddress(),
-                event.createdAt()
-        );
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleUserOrderCancelled(UserOrderCancelledEvent event) {
-        ownerOrderService.cancelOrder(event.userOrderId());
-    }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/order/owner/application/OwnerOrderServiceImpl.java
+++ b/src/main/java/com/flab/woowahaneats/domain/order/owner/application/OwnerOrderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.flab.woowahaneats.domain.order.owner.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.woowahaneats.domain.common.vo.Address;
 import com.flab.woowahaneats.domain.order.common.OrderMenu;
 import com.flab.woowahaneats.domain.order.common.OrderPrice;
@@ -13,8 +14,9 @@ import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderCookingStartedEv
 import com.flab.woowahaneats.domain.order.owner.repository.OwnerOrderRepository;
 import com.flab.woowahaneats.domain.order.user.domain.UserOrder;
 import com.flab.woowahaneats.domain.order.user.repository.UserOrderRepository;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEvent;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEventRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +29,8 @@ public class OwnerOrderServiceImpl implements OwnerOrderService {
 
     private final OwnerOrderRepository ownerOrderRepository;
     private final UserOrderRepository userOrderRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -65,7 +68,7 @@ public class OwnerOrderServiceImpl implements OwnerOrderService {
         ownerOrder.approve();
         ownerOrderRepository.save(ownerOrder);
 
-        eventPublisher.publishEvent(new OwnerOrderAcceptedEvent(userOrderId));
+        outboxEventRepository.save(OutboxEvent.create("OwnerOrderAcceptedEvent", serialize(new OwnerOrderAcceptedEvent(userOrderId))));
     }
 
     @Override
@@ -77,7 +80,7 @@ public class OwnerOrderServiceImpl implements OwnerOrderService {
         ownerOrder.startCooking();
         ownerOrderRepository.save(ownerOrder);
 
-        eventPublisher.publishEvent(new OwnerOrderCookingStartedEvent(userOrderId));
+        outboxEventRepository.save(OutboxEvent.create("OwnerOrderCookingStartedEvent", serialize(new OwnerOrderCookingStartedEvent(userOrderId))));
     }
 
     @Override
@@ -89,7 +92,15 @@ public class OwnerOrderServiceImpl implements OwnerOrderService {
         ownerOrder.completeCooking();
         ownerOrderRepository.save(ownerOrder);
 
-        eventPublisher.publishEvent(new OwnerOrderCookingCompletedEvent(userOrderId));
+        outboxEventRepository.save(OutboxEvent.create("OwnerOrderCookingCompletedEvent", serialize(new OwnerOrderCookingCompletedEvent(userOrderId))));
+    }
+
+    private String serialize(Object event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 직렬화 실패: " + event.getClass().getSimpleName(), e);
+        }
     }
 
     @Override

--- a/src/main/java/com/flab/woowahaneats/domain/order/user/application/UserOrderEventHandler.java
+++ b/src/main/java/com/flab/woowahaneats/domain/order/user/application/UserOrderEventHandler.java
@@ -1,31 +1,11 @@
 package com.flab.woowahaneats.domain.order.user.application;
 
-import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderAcceptedEvent;
-import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderCookingCompletedEvent;
-import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderCookingStartedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class UserOrderEventHandler {
 
     private final UserOrderService userOrderService;
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleOrderAccepted(OwnerOrderAcceptedEvent event) {
-        userOrderService.approveOrder(event.userOrderId());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleCookingStarted(OwnerOrderCookingStartedEvent event) {
-        userOrderService.startCooking(event.userOrderId());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleCookingCompleted(OwnerOrderCookingCompletedEvent event) {
-        userOrderService.completeCooking(event.userOrderId());
-    }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/order/user/application/UserOrderServiceImpl.java
+++ b/src/main/java/com/flab/woowahaneats/domain/order/user/application/UserOrderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.flab.woowahaneats.domain.order.user.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.woowahaneats.domain.auth.AuthContextHolder;
 import com.flab.woowahaneats.domain.cart.domain.Cart;
 import com.flab.woowahaneats.domain.cart.domain.CartMenu;
@@ -24,6 +25,8 @@ import com.flab.woowahaneats.domain.order.user.event.UserOrderCancelledEvent;
 import com.flab.woowahaneats.domain.order.user.repository.UserOrderRepository;
 import com.flab.woowahaneats.domain.payment.application.PaymentService;
 import com.flab.woowahaneats.domain.payment.domain.Payment;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEvent;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEventRepository;
 import com.flab.woowahaneats.domain.restaurant.domain.RestaurantOperationInfo;
 import com.flab.woowahaneats.domain.restaurant.repository.RestaurantOperationInfoRepository;
 import com.flab.woowahaneats.domain.user.domain.User;
@@ -44,6 +47,8 @@ public class UserOrderServiceImpl implements UserOrderService {
     private final RestaurantOperationInfoRepository restaurantOperationInfoRepository;
     private final PaymentService paymentService;
     private final ApplicationEventPublisher eventPublisher;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -112,7 +117,7 @@ public class UserOrderServiceImpl implements UserOrderService {
 
         paymentService.refundPayment(orderId, "사용자 주문 취소");
 
-        eventPublisher.publishEvent(new UserOrderCancelledEvent(orderId));
+        outboxEventRepository.save(OutboxEvent.create("UserOrderCancelledEvent", serialize(new UserOrderCancelledEvent(orderId))));
     }
 
     @Override
@@ -184,6 +189,14 @@ public class UserOrderServiceImpl implements UserOrderService {
         return orders.stream()
                 .map(OrderResponse::from)
                 .toList();
+    }
+
+    private String serialize(Object event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 직렬화 실패: " + event.getClass().getSimpleName(), e);
+        }
     }
 
     private List<OrderMenu> convertToOrderMenus(Cart cart) {

--- a/src/main/java/com/flab/woowahaneats/domain/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/application/PaymentServiceImpl.java
@@ -1,6 +1,5 @@
 package com.flab.woowahaneats.domain.payment.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.woowahaneats.domain.auth.AuthContextHolder;
 import com.flab.woowahaneats.domain.order.user.domain.UserOrder;
@@ -77,8 +76,12 @@ public class PaymentServiceImpl implements PaymentService {
         }
     }
 
-    private String serialize(Object event) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(event);
+    private String serialize(Object event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new RuntimeException("이벤트 직렬화 실패: " + event.getClass().getSimpleName(), e);
+        }
     }
 
     private void approvePayment(Payment payment, String paymentKey, String gatewayOrderId, int amount) {

--- a/src/main/java/com/flab/woowahaneats/domain/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/application/PaymentServiceImpl.java
@@ -1,5 +1,7 @@
 package com.flab.woowahaneats.domain.payment.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.woowahaneats.domain.auth.AuthContextHolder;
 import com.flab.woowahaneats.domain.order.user.domain.UserOrder;
 import com.flab.woowahaneats.domain.payment.domain.Payment;
@@ -11,10 +13,11 @@ import com.flab.woowahaneats.domain.payment.exception.PaymentNotFoundException;
 import com.flab.woowahaneats.domain.payment.gateway.PaymentApprovalResult;
 import com.flab.woowahaneats.domain.payment.gateway.PaymentGateway;
 import com.flab.woowahaneats.domain.payment.gateway.PaymentGatewayResolver;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEvent;
+import com.flab.woowahaneats.domain.payment.outbox.OutboxEventRepository;
 import com.flab.woowahaneats.domain.payment.repository.PaymentRepository;
 import com.flab.woowahaneats.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +27,8 @@ public class PaymentServiceImpl implements PaymentService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentGatewayResolver gatewayRegistry;
-    private final ApplicationEventPublisher eventPublisher;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
     private final PaymentFailureRecorder failureRecorder;
 
     @Override
@@ -56,7 +60,7 @@ public class PaymentServiceImpl implements PaymentService {
             approvePayment(payment, paymentKey, gatewayOrderId, amount);
             paymentRepository.save(payment);
 
-            eventPublisher.publishEvent(new PaymentCompletedEvent(
+            PaymentCompletedEvent event = new PaymentCompletedEvent(
                     order.getId(),
                     order.getUser().getId(),
                     order.getRestaurant().getId(),
@@ -65,11 +69,16 @@ public class PaymentServiceImpl implements PaymentService {
                     order.getOrderPrice(),
                     order.getDeliveryAddress(),
                     order.getCreatedAt()
-            ));
+            );
+            outboxEventRepository.save(OutboxEvent.create("PaymentCompletedEvent", serialize(event)));
         } catch (Exception e) {
             failureRecorder.recordFailure(payment, e.getMessage());
             throw new PaymentApprovalFailedException("결제 승인 실패: " + e.getMessage());
         }
+    }
+
+    private String serialize(Object event) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(event);
     }
 
     private void approvePayment(Payment payment, String paymentKey, String gatewayOrderId, int amount) {

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEvent.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEvent.java
@@ -1,0 +1,48 @@
+package com.flab.woowahaneats.domain.payment.outbox;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_events")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static OutboxEvent create(String eventType, String payload) {
+        return OutboxEvent.builder()
+                .eventType(eventType)
+                .payload(payload)
+                .published(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void markPublished() {
+        this.published = true;
+    }
+}

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventMarkPublisher.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventMarkPublisher.java
@@ -1,0 +1,19 @@
+package com.flab.woowahaneats.domain.payment.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventMarkPublisher {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markPublished(OutboxEvent outboxEvent) {
+        outboxEvent.markPublished();
+        outboxEventRepository.save(outboxEvent);
+    }
+}

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
@@ -1,14 +1,22 @@
 package com.flab.woowahaneats.domain.payment.outbox;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.woowahaneats.domain.delivery.event.DeliveryAcceptedEvent;
+import com.flab.woowahaneats.domain.delivery.event.DeliveryCancelledEvent;
+import com.flab.woowahaneats.domain.delivery.event.DeliveryCompletedEvent;
+import com.flab.woowahaneats.domain.delivery.event.DeliveryCreatedEvent;
 import com.flab.woowahaneats.domain.order.owner.application.OwnerOrderService;
+import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderAcceptedEvent;
+import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderCookingCompletedEvent;
+import com.flab.woowahaneats.domain.order.owner.event.OwnerOrderCookingStartedEvent;
+import com.flab.woowahaneats.domain.order.user.application.UserOrderService;
+import com.flab.woowahaneats.domain.order.user.event.UserOrderCancelledEvent;
 import com.flab.woowahaneats.domain.payment.event.PaymentCompletedEvent;
+import com.flab.woowahaneats.domain.rider.application.RiderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -20,6 +28,9 @@ public class OutboxEventPoller {
     private final OutboxEventRepository outboxEventRepository;
     private final ObjectMapper objectMapper;
     private final OwnerOrderService ownerOrderService;
+    private final UserOrderService userOrderService;
+    private final RiderService riderService;
+    private final OutboxEventMarkPublisher markPublisher;
 
     @Scheduled(fixedDelay = 5000)
     public void poll() {
@@ -27,7 +38,7 @@ public class OutboxEventPoller {
         for (OutboxEvent outboxEvent : unpublished) {
             try {
                 dispatch(outboxEvent);
-                markPublished(outboxEvent);
+                markPublisher.markPublished(outboxEvent);
             } catch (Exception e) {
                 log.error("Outbox 이벤트 처리 실패 [id={}, type={}]: {}",
                         outboxEvent.getId(), outboxEvent.getEventType(), e.getMessage(), e);
@@ -51,13 +62,45 @@ public class OutboxEventPoller {
                         event.createdAt()
                 );
             }
+            case "UserOrderCancelledEvent" -> {
+                UserOrderCancelledEvent event = objectMapper.readValue(payload, UserOrderCancelledEvent.class);
+                ownerOrderService.cancelOrder(event.userOrderId());
+            }
+            case "OwnerOrderAcceptedEvent" -> {
+                OwnerOrderAcceptedEvent event = objectMapper.readValue(payload, OwnerOrderAcceptedEvent.class);
+                userOrderService.approveOrder(event.userOrderId());
+            }
+            case "OwnerOrderCookingStartedEvent" -> {
+                OwnerOrderCookingStartedEvent event = objectMapper.readValue(payload, OwnerOrderCookingStartedEvent.class);
+                userOrderService.startCooking(event.userOrderId());
+            }
+            case "OwnerOrderCookingCompletedEvent" -> {
+                OwnerOrderCookingCompletedEvent event = objectMapper.readValue(payload, OwnerOrderCookingCompletedEvent.class);
+                userOrderService.completeCooking(event.userOrderId());
+            }
+            case "DeliveryCreatedEvent" -> {
+                DeliveryCreatedEvent event = objectMapper.readValue(payload, DeliveryCreatedEvent.class);
+                userOrderService.startDelivering(event.orderId());
+            }
+            case "DeliveryCancelledEvent" -> {
+                DeliveryCancelledEvent event = objectMapper.readValue(payload, DeliveryCancelledEvent.class);
+                userOrderService.resetOrderToReady(event.orderId());
+                if (event.riderId() != null) {
+                    riderService.finishDelivering(event.riderId());
+                }
+            }
+            case "DeliveryAcceptedEvent" -> {
+                DeliveryAcceptedEvent event = objectMapper.readValue(payload, DeliveryAcceptedEvent.class);
+                riderService.startDelivering(event.riderId());
+            }
+            case "DeliveryCompletedEvent" -> {
+                DeliveryCompletedEvent event = objectMapper.readValue(payload, DeliveryCompletedEvent.class);
+                userOrderService.completeOrder(event.orderId());
+                if (event.riderId() != null) {
+                    riderService.finishDelivering(event.riderId());
+                }
+            }
             default -> throw new IllegalArgumentException("알 수 없는 이벤트 타입: " + type);
         }
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markPublished(OutboxEvent outboxEvent) {
-        outboxEvent.markPublished();
-        outboxEventRepository.save(outboxEvent);
     }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
@@ -1,0 +1,48 @@
+package com.flab.woowahaneats.domain.payment.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.woowahaneats.domain.payment.event.PaymentCompletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventPoller {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void poll() {
+        List<OutboxEvent> unpublished = outboxEventRepository.findByPublishedFalse();
+        for (OutboxEvent outboxEvent : unpublished) {
+            try {
+                Object event = deserialize(outboxEvent);
+                eventPublisher.publishEvent(event);
+                outboxEvent.markPublished();
+            } catch (Exception e) {
+                log.error("Outbox 이벤트 발행 실패 [id={}, type={}]: {}",
+                        outboxEvent.getId(), outboxEvent.getEventType(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private Object deserialize(OutboxEvent outboxEvent) throws Exception {
+        String type = outboxEvent.getEventType();
+        String payload = outboxEvent.getPayload();
+
+        return switch (type) {
+            case "PaymentCompletedEvent" -> objectMapper.readValue(payload, PaymentCompletedEvent.class);
+            default -> throw new IllegalArgumentException("알 수 없는 이벤트 타입: " + type);
+        };
+    }
+}

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventPoller.java
@@ -1,12 +1,13 @@
 package com.flab.woowahaneats.domain.payment.outbox;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.woowahaneats.domain.order.owner.application.OwnerOrderService;
 import com.flab.woowahaneats.domain.payment.event.PaymentCompletedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -17,32 +18,46 @@ import java.util.List;
 public class OutboxEventPoller {
 
     private final OutboxEventRepository outboxEventRepository;
-    private final ApplicationEventPublisher eventPublisher;
     private final ObjectMapper objectMapper;
+    private final OwnerOrderService ownerOrderService;
 
     @Scheduled(fixedDelay = 5000)
-    @Transactional
     public void poll() {
         List<OutboxEvent> unpublished = outboxEventRepository.findByPublishedFalse();
         for (OutboxEvent outboxEvent : unpublished) {
             try {
-                Object event = deserialize(outboxEvent);
-                eventPublisher.publishEvent(event);
-                outboxEvent.markPublished();
+                dispatch(outboxEvent);
+                markPublished(outboxEvent);
             } catch (Exception e) {
-                log.error("Outbox 이벤트 발행 실패 [id={}, type={}]: {}",
+                log.error("Outbox 이벤트 처리 실패 [id={}, type={}]: {}",
                         outboxEvent.getId(), outboxEvent.getEventType(), e.getMessage(), e);
             }
         }
     }
 
-    private Object deserialize(OutboxEvent outboxEvent) throws Exception {
+    private void dispatch(OutboxEvent outboxEvent) throws Exception {
         String type = outboxEvent.getEventType();
         String payload = outboxEvent.getPayload();
 
-        return switch (type) {
-            case "PaymentCompletedEvent" -> objectMapper.readValue(payload, PaymentCompletedEvent.class);
+        switch (type) {
+            case "PaymentCompletedEvent" -> {
+                PaymentCompletedEvent event = objectMapper.readValue(payload, PaymentCompletedEvent.class);
+                ownerOrderService.createOrder(
+                        event.userOrderId(),
+                        event.orderMenus(),
+                        event.orderRequest(),
+                        event.orderPrice(),
+                        event.deliveryAddress(),
+                        event.createdAt()
+                );
+            }
             default -> throw new IllegalArgumentException("알 수 없는 이벤트 타입: " + type);
-        };
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markPublished(OutboxEvent outboxEvent) {
+        outboxEvent.markPublished();
+        outboxEventRepository.save(outboxEvent);
     }
 }

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventRepository.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventRepository.java
@@ -1,9 +1,11 @@
 package com.flab.woowahaneats.domain.payment.outbox;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
 
     List<OutboxEvent> findByPublishedFalse();

--- a/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventRepository.java
+++ b/src/main/java/com/flab/woowahaneats/domain/payment/outbox/OutboxEventRepository.java
@@ -1,0 +1,10 @@
+package com.flab.woowahaneats.domain.payment.outbox;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+
+    List<OutboxEvent> findByPublishedFalse();
+}

--- a/src/main/java/com/flab/woowahaneats/domain/rider/event/RiderEventHandler.java
+++ b/src/main/java/com/flab/woowahaneats/domain/rider/event/RiderEventHandler.java
@@ -1,36 +1,12 @@
 package com.flab.woowahaneats.domain.rider.event;
 
-import com.flab.woowahaneats.domain.delivery.event.DeliveryAcceptedEvent;
-import com.flab.woowahaneats.domain.delivery.event.DeliveryCancelledEvent;
-import com.flab.woowahaneats.domain.delivery.event.DeliveryCompletedEvent;
 import com.flab.woowahaneats.domain.rider.application.RiderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
 public class RiderEventHandler {
 
     private final RiderService riderService;
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryAccepted(DeliveryAcceptedEvent event) {
-        riderService.startDelivering(event.riderId());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryCompleted(DeliveryCompletedEvent event) {
-        if (event.riderId() != null) {
-            riderService.finishDelivering(event.riderId());
-        }
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDeliveryCancelled(DeliveryCancelledEvent event) {
-        if (event.riderId() != null) {
-            riderService.finishDelivering(event.riderId());
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- `OutboxEvent` 엔티티와 `outbox_events` 테이블 추가 (Hibernate DDL 자동 생성)
- `OutboxEventPoller` 스케줄러: 5초마다 미발행 이벤트를 조회해 직접 서비스 호출 후 처리
- `PaymentServiceImpl.confirmPayment()`: 인메모리 `publishEvent()` → `outbox_events` DB 저장으로 교체

## 흐름

```mermaid
sequenceDiagram
    participant S as PaymentService
    participant DB as DB (같은 트랜잭션)
    participant P as OutboxEventPoller (5초마다)
    participant OS as OwnerOrderService

    S->>DB: Payment 저장 + outbox_events 저장 (원자적)
    Note over DB: 둘 다 커밋 or 둘 다 롤백
    P->>DB: SELECT * FROM outbox_events WHERE published = false
    P->>OS: ownerOrderService.createOrder() 직접 호출
    Note over P: 성공 시에만 markPublished()
    P->>DB: published = true (REQUIRES_NEW 트랜잭션)
```

## Before / After 비교

| 상황 | Before (인메모리 이벤트) | After (Outbox) |
|---|---|---|
| 서버가 커밋 직후 재시작 | 이벤트 유실, OwnerOrder 미생성 | outbox 레코드 남아 재시작 후 Poller가 재처리 |
| Payment 롤백 | OwnerOrder 불일치 가능 | outbox도 같이 롤백 (원자적) |
| 핸들러 실패 | published=true 되는 버그 없음(해당 없음) | 실패 시 published=false 유지 → 재시도 |

## 검증 결과

로컬 DB에서 직접 확인:
1. `outbox_events` 테이블 생성 확인
2. `published=false` 레코드 삽입 → 5초 내 `published=true` 변경 확인
3. `owner_orders` 레코드 생성 확인 (`INSERT INTO owner_orders` 실행됨)

## 범위 외

Saga 보상 로직 (OwnerOrder 생성 실패 시 결제 환불) — 별도 이슈 예정

closes #100

## Test plan

- [x] 앱 기동 후 `outbox_events` 테이블 자동 생성 확인
- [x] `published=false` 이벤트 삽입 → 5초 내 `published=true` 변경 확인
- [x] `owner_orders` 레코드 생성 확인
- [ ] 핸들러 실패 시 `published=false` 유지 후 재시도 확인 (수동 테스트 필요)